### PR TITLE
post-scan output (print results)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ SRC =	main.c \
 		scan_send_probe.c \
 		scan_interpret_response.c \
 		scan_utils.c \
-		utils.c
+		utils.c \
+		print_results.c
 
 OBJ_DIR = .obj/
 OBJ = $(SRC:%.c=$(OBJ_DIR)%.o)

--- a/inc/ft_nmap.h
+++ b/inc/ft_nmap.h
@@ -43,7 +43,8 @@ enum	probe_response
 };
 
 // 1 second, which is the default timeout for nmap, you can check it with -Pn option
-// -Pn option means that the scan will be performed without pinging the target, so no timeout measurement is done (which helps to speed up the scan)
+// -Pn option means that the scan will be performed without pinging the target, 
+// so no timeout measurement is done (which is supposed to help to speed up the scan)
 #define INITIAL_RTT_TIMEOUT 1 
 
 // BPF filter for capturing relevant packets for port TCP/SYN scan result
@@ -117,7 +118,7 @@ struct	ports
 	unsigned short int	udp;
 };
 
-// handle in the struct is set to NULL right before being closed so
+// the handle in the struct is set to NULL right before being closed so
 // pcap_breakloop isn't called on a handle that's been closed
 struct	timer_data
 {

--- a/inc/ft_nmap.h
+++ b/inc/ft_nmap.h
@@ -99,6 +99,7 @@ struct	task
 	struct task			*next;
 };
 
+// per target
 struct	result
 {
 	in_addr_t	target;
@@ -162,5 +163,6 @@ char	*trim_whitespaces(char *str);
 void	print_task(struct task task);
 const char *scan_result_to_str(enum scan_result r);
 void	print_results_debug(void);
+void	print_results(double scan_duration);
 
 #endif

--- a/inc/ft_nmap.h
+++ b/inc/ft_nmap.h
@@ -164,6 +164,7 @@ char	*trim_whitespaces(char *str);
 void	print_task(struct task task);
 const char *scan_result_to_str(enum scan_result r);
 void	print_results_debug(void);
+void	print_scan_config(void);
 void	print_results(double scan_duration);
 
 #endif

--- a/src/ft_nmap.c
+++ b/src/ft_nmap.c
@@ -413,7 +413,7 @@ int ft_nmap() {
 	}
 	bzero(threads, nmap.threads * sizeof(pthread_t));
 
-	print_tasks(tasks);
+	//print_tasks(tasks);
 	for (int i = 0; i < nmap.threads; i++) {
 		if (pthread_create(&threads[i], NULL, thread_routine, NULL) == -1) {
 			perror("pthread_create-> ");

--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,7 @@ struct nmap nmap = {
 struct ports	ports;
 int				send_sock;
 struct task		*tasks = NULL; // liste chaînée
-struct result	*results = NULL; // array
+struct result	*results = NULL; // array of results per target
 size_t			nb_results = 0;
 pthread_mutex_t	task_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t	result_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/main.c
+++ b/src/main.c
@@ -105,6 +105,8 @@ int main(int argc, char **argv)
 	struct timespec start, end;
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	
+	print_scan_config();
+	printf("Scanning..\n");
 	if (ft_nmap())
 	{
 		free(tasks);

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include <sys/socket.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <time.h>
 
 #include "ft_nmap.h"
 
@@ -95,12 +96,24 @@ int main(int argc, char **argv)
 	}
 	if (create_recv_sockets()
 		|| create_send_sockets()
-		|| create_tasks()
-		|| ft_nmap())
+		|| create_tasks())
 	{
 		free(tasks);
 		return (2);
 	}
-	print_results_debug();
+	
+	struct timespec start, end;
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	
+	if (ft_nmap())
+	{
+		free(tasks);
+		return (2);
+	}
+	
+	clock_gettime(CLOCK_MONOTONIC, &end);
+	double duration = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+	
+	print_results(duration);
 	return (0);
 }

--- a/src/print_results.c
+++ b/src/print_results.c
@@ -174,8 +174,6 @@ void print_results(double scan_duration)
 		enabled_scans[0] = nmap.scan;
 	}
 	
-	print_scan_config();
-	printf("Scanning..\n");
 	print_scan_duration(scan_duration);
 	
 	// nb_results is the number of targets to scan

--- a/src/print_results.c
+++ b/src/print_results.c
@@ -1,0 +1,240 @@
+	#include "ft_nmap.h"
+#include <stdio.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <time.h>
+
+// Get service name for a port using getservbyport
+// Returns "Unassigned" if no service found
+const char *get_service_name(uint16_t port)
+{
+	struct servent *serv;
+
+	// Try TCP first (most common)
+	serv = getservbyport(htons(port), "tcp");
+	if (serv)
+		return serv->s_name;
+	
+	// Try UDP
+	serv = getservbyport(htons(port), "udp");
+	if (serv)
+		return serv->s_name;
+	
+	return "Unassigned";
+}
+
+// Get scan type name as string
+const char *scan_type_to_str(enum scan_type scan)
+{
+	switch (scan)
+	{
+		case SYN: return "SYN";
+		case NUL: return "NULL";
+		case ACK: return "ACK";
+		case FIN: return "FIN";
+		case XMAS: return "XMAS";
+		case UDP: return "UDP";
+		default: return "UNKNOWN";
+	}
+}
+
+// Get capitalized scan result string for conclusion
+const char *scan_result_to_str_capitalized(enum scan_result r)
+{
+	switch (r)
+	{
+		case SR_OPEN: return "Open";
+		case SR_CLOSED: return "Closed";
+		case SR_FILTERED: return "Filtered";
+		case SR_UNFILTERED: return "Unfiltered";
+		case SR_OPEN_FILTERED: return "Open|Filtered";
+		default: return "Unknown";
+	}
+}
+
+// Format scan result for display (e.g., "SYN (Open)", "NULL (Closed)")
+void format_scan_result(char *buf, size_t buf_size, enum scan_type scan, enum scan_result result)
+{
+	const char *scan_str = scan_type_to_str(scan);
+	const char *result_str = scan_result_to_str_capitalized(result);
+	
+	snprintf(buf, buf_size, "%s (%s)", scan_str, result_str);
+}
+
+// Determine final conclusion for a port based on all scan results
+// This is a simplified version - we can refine the logic
+enum scan_result determine_final_conclusion(uint32_t port_value, enum scan_type enabled_scans[])
+{
+	// For now, prioritize OPEN results
+	// If any scan shows OPEN, the port is OPEN
+	// Otherwise, check other states
+	
+	bool has_open = false;
+	bool has_unfiltered = false;
+	bool has_filtered = false;
+	
+	// Check each enabled scan type
+	for (int i = 0; enabled_scans[i] != -1 && i < 6; i++)
+	{
+		enum scan_type scan = enabled_scans[i];
+		enum scan_result result = (enum scan_result)((port_value >> (scan * 3)) & 0x7);
+		
+		if (result == SR_OPEN)
+			has_open = true;
+		else if (result == SR_UNFILTERED)
+			has_unfiltered = true;
+		else if (result == SR_FILTERED || result == SR_OPEN_FILTERED)
+			has_filtered = true;
+	}
+	
+	if (has_open)
+		return SR_OPEN;
+	if (has_unfiltered)
+		return SR_UNFILTERED;
+	if (has_filtered)
+		return SR_FILTERED;
+	
+	return SR_CLOSED;
+}
+
+// Print scan configuration header
+void print_scan_config(void)
+{
+	struct in_addr addr;
+	char ip_str[INET_ADDRSTRLEN];
+	
+	printf("\nScan Configurations:\n");
+	
+	// Target IP - we'll use the first result's target
+	if (nb_results > 0)
+	{
+		addr.s_addr = results[0].target;
+		if (inet_ntop(AF_INET, &addr, ip_str, INET_ADDRSTRLEN))
+			printf("  Target Ip-Address: %s\n", ip_str);
+	}
+	
+	// Number of ports
+	printf("  No of Ports to scan: %u\n", nmap.port_end - nmap.port_start + 1);
+	
+	// Scans to be performed
+	printf("  Scans to be performed: ");
+	if (nmap.scan == ALL)
+		printf("SYN NULL FIN XMAS ACK UDP\n");
+	else
+		printf("%s\n", scan_type_to_str(nmap.scan));
+	
+	// Number of threads
+	printf("  No of threads: %u\n", nmap.threads);
+}
+
+// Print scan duration
+void print_scan_duration(double duration_secs)
+{
+	printf("Scan took %.5f secs\n", duration_secs);
+}
+
+// Print results table header
+void print_table_header(void)
+{
+	printf("%-8s %-30s %-60s %-15s\n", "Port", "Service Name (if applicable)", "Results", "Conclusion");
+	printf("%-8s %-30s %-60s %-15s\n", "----", "----------------------------", "-------", "----------");
+}
+
+// Print a single port result row
+void print_port_result(uint16_t port, uint32_t port_value, enum scan_type enabled_scans[])
+{
+	const char *service = get_service_name(port);
+	char results_buf[256] = {0};
+	char temp_buf[64];
+	bool first = true;
+	
+	// Build results string
+	for (int i = 0; enabled_scans[i] != -1 && i < 6; i++)
+	{
+		enum scan_type scan = enabled_scans[i];
+		enum scan_result result = (enum scan_result)((port_value >> (scan * 3)) & 0x7);
+		
+		if (!first)
+			strcat(results_buf, ", ");
+		
+		format_scan_result(temp_buf, sizeof(temp_buf), scan, result);
+		strcat(results_buf, temp_buf);
+		first = false;
+	}
+	
+	enum scan_result final = determine_final_conclusion(port_value, enabled_scans);
+	const char *conclusion = scan_result_to_str_capitalized(final);
+	
+	printf("%-8u %-30s %-60s %-15s\n", port, service, results_buf, conclusion);
+}
+
+// Main function to print all results
+void print_results(double scan_duration)
+{
+	size_t i;
+	enum scan_type enabled_scans[7] = {-1, -1, -1, -1, -1, -1, -1};
+	
+	// Build list of enabled scan types
+	if (nmap.scan == ALL)
+	{
+		enabled_scans[0] = SYN;
+		enabled_scans[1] = NUL;
+		enabled_scans[2] = ACK;
+		enabled_scans[3] = FIN;
+		enabled_scans[4] = XMAS;
+		enabled_scans[5] = UDP;
+	}
+	else
+	{
+		enabled_scans[0] = nmap.scan;
+	}
+	
+	// Print configuration
+	print_scan_config();
+	printf("Scanning..\n");
+	print_scan_duration(scan_duration);
+	
+	// Process each target
+	for (i = 0; i < nb_results; i++)
+	{
+		struct in_addr addr;
+		char ip_str[INET_ADDRSTRLEN];
+		size_t nb_ports = nmap.port_end - nmap.port_start + 1;
+		size_t p;
+		
+		addr.s_addr = results[i].target;
+		if (!inet_ntop(AF_INET, &addr, ip_str, INET_ADDRSTRLEN))
+			continue;
+		
+		printf("\nIP address: %s\n", ip_str);
+		
+		// Separate open ports from closed/filtered/unfiltered
+		printf("\nOpen ports:\n");
+		print_table_header();
+		
+		for (p = 0; p < nb_ports; p++)
+		{
+			uint16_t port = (uint16_t)(nmap.port_start + p);
+			uint32_t port_value = results[i].results[p];
+			enum scan_result final = determine_final_conclusion(port_value, enabled_scans);
+			
+			if (final == SR_OPEN)
+				print_port_result(port, port_value, enabled_scans);
+		}
+		
+		printf("\nClosed/Filtered/Unfiltered ports:\n");
+		print_table_header();
+		
+		for (p = 0; p < nb_ports; p++)
+		{
+			uint16_t port = (uint16_t)(nmap.port_start + p);
+			uint32_t port_value = results[i].results[p];
+			enum scan_result final = determine_final_conclusion(port_value, enabled_scans);
+			
+			if (final != SR_OPEN)
+				print_port_result(port, port_value, enabled_scans);
+		}
+	}
+}
+

--- a/src/print_results.c
+++ b/src/print_results.c
@@ -151,7 +151,8 @@ void print_port_result(uint16_t port, uint32_t port_value, enum scan_type enable
 	printf("%-8u %-30s %-60s %-15s\n", port, service, results_buf, conclusion);
 }
 
-// Main function to print all results
+// Main function
+// prints all the post-scan output (scan config, scan duration, results for each target)
 void print_results(double scan_duration)
 {
 	size_t i;
@@ -173,12 +174,12 @@ void print_results(double scan_duration)
 		enabled_scans[0] = nmap.scan;
 	}
 	
-	// Print configuration
 	print_scan_config();
 	printf("Scanning..\n");
 	print_scan_duration(scan_duration);
 	
-	// Process each target
+	// nb_results is the number of targets to scan
+	// prints results for each target
 	for (i = 0; i < nb_results; i++)
 	{
 		struct in_addr addr;


### PR DESCRIPTION
Multi target support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds structured post-scan output (scan configuration, duration, and per-target port result tables with service names and conclusions) and integrates it into main flow.
> 
> - **Results Output**:
>   - Add `src/print_results.c` to render post-scan details: scan configuration, total duration, and per-target port tables.
>   - Show service names, per-scan outcomes, and a final conclusion per port; separate open from other states.
> - **Integration**:
>   - In `main.c`, measure scan duration with `clock_gettime`, print scan config, run scan, then print results.
>   - Export `print_scan_config` and `print_results` in `inc/ft_nmap.h`.
> - **Build**:
>   - Include `print_results.c` in `Makefile` build.
> - **Misc**:
>   - Silence task debug print in `ft_nmap.c`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eff21a5befab72b8a51174dab2085caefbe29797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->